### PR TITLE
mention all of the authors of the formlets paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # halogen-form
 
-This implements formlets as in the Wadler paper
+This implements formlets as in Cooper, Lindley, Wadler and Yallop's paper
 [_The Essence of Form Abstraction_](http://homepages.inf.ed.ac.uk/slindley/papers/formlets-essence.pdf)
 for the halogen package.
 


### PR DESCRIPTION
There are 4 authors on this paper and calling it a "Wadler paper" erases the contribution of the other authors. The authors names are in alphabetical order, which usually indicates that they should all be given equal attribution for the work.